### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
     "paper-menu": "PolymerElements/paper-menu#^1.2.2",
     "paper-item": "PolymerElements/paper-item#^1.2.1",
     "paper-input-items": "PolymerEl/paper-input-items#^0.1.2",
-    "firebase-nest": "firebase-nest"
+    "firebase-nest": "*"
   },
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",


### PR DESCRIPTION
Having "firebase-nest" set as the required version causes Bower to look for a tag with that name in the repository. Since such a tag doesn't exist there, it causes `bower install` to fail.